### PR TITLE
Fix IP address being null inside Scanner.php

### DIFF
--- a/src/Scanner.php
+++ b/src/Scanner.php
@@ -85,9 +85,9 @@ class Scanner
             if ($this->CalledFrom === 'CLI') {
                 $Origin = 'CLI';
             } elseif ($this->Loader->Configuration['legal']['pseudonymise_ip_addresses']) {
-                $Origin = $this->Loader->pseudonymiseIP($this->IPAddr);
+                $Origin = $this->Loader->pseudonymiseIP($this->Loader->IPAddr);
             } else {
-                $Origin = $this->IPAddr;
+                $Origin = $this->Loader->IPAddr;
             }
 
             /** Get detections. */
@@ -1014,7 +1014,7 @@ class Scanner
                 $this->quarantine(
                     $In,
                     $this->Loader->Configuration['quarantine']['quarantine_key'],
-                    $this->IPAddr,
+                    $this->Loader->IPAddr,
                     $qfu
                 );
                 $this->Loader->HashReference .= sprintf($this->Loader->L10N->getString('response.Quarantined as'), $qfu) . "\n";
@@ -1086,7 +1086,7 @@ class Scanner
                 $this->quarantine(
                     $In,
                     $this->Loader->Configuration['quarantine']['quarantine_key'],
-                    $this->IPAddr,
+                    $this->Loader->IPAddr,
                     $qfu
                 );
                 $this->Loader->HashReference .= sprintf($this->Loader->L10N->getString('response.Quarantined as'), $qfu);


### PR DESCRIPTION
In my case, I have quarantine enabled with a key and was getting the following error when quarantine was invoked:

Argument 3 passed to phpMussel\Core\Scanner::quarantine() must be of the type string, null given, called in /srv/vendor/phpmussel/core/src/Scanner.php on line 1015

1. /srv/vendor/phpmussel/core/src/Scanner.php L412 `public function quarantine(string $In, string $Key, string $IP, string $ID): bool`
2. /srv/vendor/phpmussel/core/src/Scanner.php L1015 ```$this->quarantine(
                    $In,
                    $this->Loader->Configuration['quarantine']['quarantine_key'],
                    $this->IPAddr,
                    $qfu
                );```

`$this->IPAddr` evaluates to null and this PR fixes this by using the IP value as instantiated in the Loader class.